### PR TITLE
fix: allow blank metadata field in models.py

### DIFF
--- a/usermanagement/models.py
+++ b/usermanagement/models.py
@@ -126,7 +126,7 @@ class Context(models.Model):
     )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
-    metadata = models.JSONField(default=dict)
+    metadata = models.JSONField(default=dict, blank=True)
 
     def __str__(self):
         return f"{self.name} - {self.context_type}"


### PR DESCRIPTION
fix: allow blank metadata field in models.py