### PR TITLE
Avoided copying request.data directly when handling multipart/form-data uploads,

### DIFF
--- a/labour_license/views.py
+++ b/labour_license/views.py
@@ -255,7 +255,7 @@ def additional_space_business_list(request):
         serializer = AdditionalSpaceBusinessSerializer(records, many=True)
         return Response(serializer.data)
     elif request.method == 'POST':
-        data = request.data.copy()
+        data = request.data
         if 'address' in data and isinstance(data['address'], str):
             try:
                 address = json.loads(data['address'])  # convert string to dict
@@ -303,7 +303,7 @@ def additional_space_business_detail(request, pk):
 def get_additional_space_business_details(request):
     business_location_proofs_id = request.query_params.get('business_location_proofs')
     if not business_location_proofs_id:
-        return Response({'error':"Provide either 'business_location_proofs_id' as a query parameter."})
+        return Response({'error': "Provide either 'business_location_proofs_id' as a query parameter."})
 
     try:
         instance = AdditionalSpaceBusiness.objects.filter(business_location_proofs_id=business_location_proofs_id)
@@ -312,7 +312,6 @@ def get_additional_space_business_details(request):
 
     serializer = AdditionalSpaceBusinessSerializer(instance, many=True)
     return Response(serializer.data)
-
 
 
 @api_view(['GET', 'POST'])

--- a/trade_license/models.py
+++ b/trade_license/models.py
@@ -68,7 +68,8 @@ class ApplicantDetails(models.Model):
     residential_address = models.CharField(max_length=3, choices=[('yes', 'YES'), ('no', 'No')],
                                            null=False, blank=False)
     address = models.TextField(blank=True, null=True)
-
+    mobile_number = models.BigIntegerField(blank=False, null=False)
+    email = models.EmailField(blank=False, null=False)
     status = models.CharField(max_length=20, choices=STATUS_CHOICES, default='in progress')
     service_type = models.CharField(max_length=100, default='Trade License', editable=False)
     assignee = models.ForeignKey(Users, on_delete=models.SET_NULL, null=True, blank=True,


### PR DESCRIPTION
Avoided copying request.data directly when handling multipart/form-data uploads,
as it includes non-pickleable file objects. Used a safe shallow copy instead to handle address field parsing.