### PR TITLE
fix: update URL patterns for document deletion to include 'files' in path

### DIFF
--- a/income_tax_returns/urls.py
+++ b/income_tax_returns/urls.py
@@ -54,7 +54,7 @@ urlpatterns = [
          name='salary_income_list_create'),
     path('salary-income/<int:pk>/', salary_income_views.salary_income_detail,
          name='salary_income_detail_update'),
-    path('salary-documents/<int:pk>/delete/', salary_income_views.delete_salary_document,
+    path('salary-documents/files/<int:pk>/delete/', salary_income_views.delete_salary_document,
          name='delete_salary_document_file'),
     path('salary-documents-count/<int:income_id>/', salary_income_views.salary_document_summary,
          name='salary_document_summary'),
@@ -111,7 +111,7 @@ urlpatterns = [
     path('business-professional-income/<int:service_request_id>/delete/',
          business_professional_income_views.delete_business_professional_income,
          name='delete_business_professional_income'),
-    path('business-professional-income/document/<int:file_id>/delete/',
+    path('business-professional-income/files/<int:file_id>/delete/',
          business_professional_income_views.delete_business_professional_income_file,
          name='delete_business_professional_income_file'),
 
@@ -148,7 +148,7 @@ urlpatterns = [
     # InterestIncomeDocument endpoints
     path('interest-income-doc/add/', interest_income_views.add_interest_income_document,
          name='add_interest_income_document'),
-    path('interest-income-doc/<int:document_id>/delete/', interest_income_views.delete_interest_income_document,
+    path('interest-income-doc/files/<int:document_id>/delete/', interest_income_views.delete_interest_income_document,
          name='delete_interest_income_document'),
     path('interest-income-doc/<int:document_id>/update/', interest_income_views.update_interest_income_document,
          name='update_interest_income_document'),
@@ -166,7 +166,7 @@ urlpatterns = [
          name='add_gift_income_document'),  # POST add doc
     path('gift-income-document/<int:document_id>/update/', gift_income_views.update_gift_income_document,
          name='update_gift_income_document'),  # PUT update doc
-    path('gift-income-document/<int:document_id>/delete/', gift_income_views.delete_gift_income_document,
+    path('gift-income-document/files/<int:document_id>/delete/', gift_income_views.delete_gift_income_document,
          name='delete_gift_income_document'),  # DELETE doc
     path('gift-income-document/view/', gift_income_views.get_gift_income_documents,
          name='get_gift_income_document'),  # GET by service_request
@@ -182,7 +182,7 @@ urlpatterns = [
          name='add_dividend_income_document'),  # POST add doc
     path('dividend-income-document/<int:document_id>/update/', dividend_views.update_dividend_income_document,
          name='update_dividend_income_document'),  # PUT update doc
-    path('dividend-income-document/<int:document_id>/delete/', dividend_views.delete_dividend_income_document,
+    path('dividend-income-document/files/<int:document_id>/delete/', dividend_views.delete_dividend_income_document,
          name='delete_dividend_income_document'),  # DELETE doc
     path('dividend-income-document/view/', dividend_views.list_dividend_income_documents,
          name='list_dividend_income_document'),  # GET by service_request
@@ -198,7 +198,7 @@ urlpatterns = [
     path('family-pension-income-documents/<int:document_id>/',
          family_pension_views.update_family_pension_income_document,
          name='update_family_pension_income_document'),  # PUT (update)
-    path('family-pension-income-documents/<int:document_id>/delete/',
+    path('family-pension-income-documents/files/<int:document_id>/delete/',
          family_pension_views.delete_family_pension_income_document,
          name='delete_family_pension_income_document'),  # DELETE
     path('family-pension-income-documents/view/', family_pension_views.get_family_pension_income_documents,
@@ -305,7 +305,7 @@ urlpatterns = [
 
     path('nri-salary-details/upsert/', nri_views.upsert_nri_salary_details, name='upsert-nri-salary-details'),
     path('nri-salary-details/view/', nri_views.nri_salary_details_view, name='view-nri-salary-details'),
-    path('nri-salary-details/file/<int:file_id>/delete/', nri_views.delete_nri_salary_file,
+    path('nri-salary-details/files/<int:file_id>/delete/', nri_views.delete_nri_salary_file,
          name='delete-nri-salary-file'),
 
     path('service-request-section-data', views.get_service_request_section_data,


### PR DESCRIPTION
fix: update URL patterns for document deletion to include 'files' in path