### PR TITLE
fix: add trailing slash to delete URL for Section 80D files

### DIFF
--- a/income_tax_returns/urls.py
+++ b/income_tax_returns/urls.py
@@ -298,7 +298,7 @@ urlpatterns = [
 
     # List & Delete Section80D files
     path('section-80d-files/', section_80d_views.list_section_80d_files, name='list_section_80d_files'),
-    path('section-80d/files/<int:file_id>/delete', section_80d_views.delete_section_80d_file, name='delete_section_80d_file'),
+    path('section-80d/files/<int:file_id>/delete/', section_80d_views.delete_section_80d_file, name='delete_section_80d_file'),
 
     path('service-requests-itr/<int:service_request_id>/full-data/', views.get_service_request_full_data,
          name='get_service_request_full_data'),


### PR DESCRIPTION
fix: add trailing slash to delete URL for Section 80D files