### PR TITLE
fix: handle request data copying when no files are present in upsert_equity_mutual_fund_with_files

### DIFF
--- a/income_tax_returns/capital_gains_funds_details_views.py
+++ b/income_tax_returns/capital_gains_funds_details_views.py
@@ -11,7 +11,11 @@ import json
 @parser_classes([MultiPartParser, FormParser, JSONParser])
 def upsert_equity_mutual_fund_with_files(request):
     try:
-        request_data = request.data
+        # Check if request contains files
+        if request.FILES:
+            request_data = request.data
+        else:
+            request_data = request.data.copy()
 
         # Coerce investment_types if sent as a string
         investment_types = request_data.get('equity_mutual_fund_type')

--- a/payroll/views.py
+++ b/payroll/views.py
@@ -3837,10 +3837,16 @@ def bonus_by_payroll_month_year(request):
             results.append({
                 'id': current_bonus.id,
                 'employee_id': employee.id,
+                'associate_id': employee.associate_id,
+                'department': employee.department.dept_name if employee.department else '',
+                'designation': employee.designation.designation_name if employee.designation else '',
+                'type': current_bonus.bonus_type,
                 'employee_name': employee.first_name,
                 'current_bonus': current_bonus.amount,
                 'committed_bonus': committed_bonus,
                 'ytd_bonus_paid': ytd_bonus,
+                'month': current_bonus.month,
+                'financial_year': current_bonus.financial_year,
                 'remarks': current_bonus.remarks or ''
             })
 


### PR DESCRIPTION
fix: handle request data copying when no files are present in upsert_equity_mutual_fund_with_files