### PR TITLE
fix: rename assigned_to to assignee in task serialization for consistency

### DIFF
--- a/msme_registration/views.py
+++ b/msme_registration/views.py
@@ -626,7 +626,7 @@ def get_msme_tasks_using_section_name(request):
             "status": task.status,
             "priority": task.priority,
             "due_date": task.due_date,
-            "assigned_to": task.assignee.id if task.assignee else None,
+            "assignee": task.assignee.id if task.assignee else None,
             "reviewer": task.reviewer.id if task.reviewer else None,
             "data": None
         }


### PR DESCRIPTION
fix: rename assigned_to to assignee in task serialization for consistency