### PR TITLE
fix: add EPF enabled flag to employee deductions calculation and update conditional checks

### DIFF
--- a/payroll/views.py
+++ b/payroll/views.py
@@ -1575,7 +1575,8 @@ def calculate_esi_contributions(basic_monthly, esi_enabled, payroll_id=None):
     return benefits
 
 
-def calculate_employee_deductions(pf_wage, basic_monthly, gross_monthly, pt_enabled, payroll_id=None, esi_enabled=False):
+def calculate_employee_deductions(pf_wage, basic_monthly, gross_monthly, pt_enabled, payroll_id=None, esi_enabled=False,
+                                  epf_enabled=False):
     deductions = {
         "EPF Employee Contribution": {
             "monthly": "NA",
@@ -1601,8 +1602,7 @@ def calculate_employee_deductions(pf_wage, basic_monthly, gross_monthly, pt_enab
         payroll = PayrollOrg.objects.get(id=payroll_id)
 
         # --- EPF Employee Contribution ---
-        if (
-            hasattr(payroll, 'epf_details') and payroll.epf_details):
+        if hasattr(payroll, 'epf_details') and payroll.epf_details and epf_enabled:
             if payroll.epf_details.employee_contribution_rate == "12% of Actual PF Wage":
                 epf_monthly = 0.12 * basic_monthly
             else:
@@ -1614,10 +1614,7 @@ def calculate_employee_deductions(pf_wage, basic_monthly, gross_monthly, pt_enab
             }
 
         # --- ESI Employee Contribution ---
-        if (
-            hasattr(payroll, 'esi_details') and payroll.esi_details and
-            payroll.esi_details.include_employer_contribution_in_ctc and esi_enabled
-        ):
+        if hasattr(payroll, 'esi_details') and payroll.esi_details and esi_enabled:
             if gross_monthly <= 21000:
                 esi_monthly = 0.0075 * gross_monthly
                 deductions["ESI Employee Contribution"] = {
@@ -1804,7 +1801,7 @@ def calculate_payroll(request):
             # Calculate statutory deductions
             # esi_enabled = employee.statutory_components.get("esi_enabled", False)
             statutory_deductions = calculate_employee_deductions(pf_wage, basic_salary_monthly,
-                                                    monthly_gross_salary, pt_enabled, data.get("payroll"), esi_enabled)
+                                        monthly_gross_salary, pt_enabled, data.get("payroll"), esi_enabled, epf_enabled)
 
             # Get non-statutory deductions from payload
             non_statutory_deductions = {}


### PR DESCRIPTION
### fix: add EPF enabled flag to employee deductions calculation and update conditional checks

**Issue:**

EPF deductions were still being applied even when EPF was disabled for the employee, leading to incorrect payroll calculations.

<img width="1916" height="961" alt="Screenshot 2025-08-14 130524" src="https://github.com/user-attachments/assets/eaf81fe4-f3b2-4261-a8f0-33553ae8d628" />

<img width="1912" height="952" alt="Screenshot 2025-08-14 124553" src="https://github.com/user-attachments/assets/c8e75e49-aa10-422d-b20f-77fbe022bc28" />

**Solution:** 

- Added an EPF enabled flag to the employee deductions calculation.

- Updated conditional checks so deductions are computed only when the EPF flag is set to true.

**Result:**

<img width="1919" height="1018" alt="Screenshot 2025-08-14 125305" src="https://github.com/user-attachments/assets/52945f1a-d955-4cc5-aa54-6bf7256b24bf" />

**Summary:**

This ensures payroll calculations are accurate and prevents any unintended EPF deductions when EPF is not applicable.