### PR TITLE
refactor: switch PDF generation from WeasyPrint to pdfkit

### DIFF
--- a/payroll/views.py
+++ b/payroll/views.py
@@ -4188,26 +4188,24 @@ def get_financial_year_summary(request):
 #             raise
 
 
-from weasyprint import HTML
-from django.template.loader import render_to_string
+
 
 class DocumentGenerator:
-    """Handles HTML-to-PDF document generation using WeasyPrint."""
+    """Handles HTML-to-PDF document generation using pdfkit."""
+
     def __init__(self, context):
         self.context = context
 
     def generate_pdf_bytes(self, template_name: str) -> bytes:
         """Render HTML template with context and return PDF as bytes."""
         html_content = render_to_string(template_name, self.context)
-        pdf_bytes = HTML(string=html_content).write_pdf()
-        return pdf_bytes
+        return pdfkit.from_string(html_content, False)
 
     def generate_pdf_file(self, template_name: str, output_path: str) -> str:
         """Render HTML template with context and save as PDF file."""
         html_content = render_to_string(template_name, self.context)
-        HTML(string=html_content).write_pdf(output_path)
+        pdfkit.from_string(html_content, output_path)
         return output_path
-
 
 import re
 


### PR DESCRIPTION
### refactor: switch PDF generation from WeasyPrint to pdfkit

**Issue:**
PDF generation using WeasyPrint produced incorrect alignment and inconsistent formatting across pages. This caused layout issues such as shifted text, misaligned tables, and uneven spacing, leading to a poor visual presentation of the generated PDFs.

<img width="1920" height="1080" alt="Screenshot (320)" src="https://github.com/user-attachments/assets/c5192d50-53eb-40d9-a85e-51b2f47204c7" />

**Solution:**
Replaced WeasyPrint with pdfkit (wkhtmltopdf) for PDF generation. pdfkit leverages HTML/CSS rendering via WebKit, resulting in more accurate alignment and better support for complex layouts. Updated the generation logic to use pdfkit’s configuration and options, ensuring consistent margins, page breaks, and styles.

<img width="1920" height="1080" alt="Screenshot 2025-08-13 160254" src="https://github.com/user-attachments/assets/dd8a31b9-6f99-44b2-8198-7bd832e3d491" />

**Summary:**

- Switched PDF generation library from WeasyPrint to pdfkit.
- Improved alignment, margin consistency, and table rendering in generated PDFs.
- Achieved a more stable and visually correct output across different document structures.