### PR TITLE
feat: implement WebSocket broadcasting for attendance updates

### DIFF
--- a/Tara/broadcast.py
+++ b/Tara/broadcast.py
@@ -1,0 +1,27 @@
+# broadcast.py
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+
+_channel = get_channel_layer()
+
+
+def broadcast_to_employee(employee_id: int, payload: dict):
+    """
+    Sends payload to the employee-specific group.
+    Your consumer must add connections to group: f"user_{employee_id}"
+    """
+    async_to_sync(_channel.group_send)(
+        f"user_{employee_id}",
+        {"type": "send_attendance_update", "payload": payload}
+    )
+
+
+def broadcast_to_business(business_id: int, payload: dict):
+    """
+    Sends payload to the whole business/team group.
+    Your consumer must add connections to group: f"business_{business_id}"
+    """
+    async_to_sync(_channel.group_send)(
+        f"business_{business_id}",
+        {"type": "send_attendance_update", "payload": payload}
+    )

--- a/Tara/routing.py
+++ b/Tara/routing.py
@@ -4,5 +4,5 @@ from django.urls import re_path
 from . import consumer
 
 websocket_urlpatterns = [
-    re_path(r'ws/attendance/(?P<context_id>\w+)/$', consumer.AttendanceConsumer.as_asgi()),
+    re_path(r"^ws/attendance/(?P<employee_id>\d+)/$", consumer.AttendanceConsumer.as_asgi()),
 ]


### PR DESCRIPTION
**Real‑Time Attendance & Team Notifications — Simple Why**

**Problem**
Check‑ins happened from mobile and web, but screens showed stale data and often needed a reload. Dashboards weren’t live.

**What changed**
We kept the database as the source of truth and added a lightweight live channel (WebSocket) that pushes updates the moment someone checks in or out.

**How it works (no code)**

1. User checks in/out → server saves to DB.
2. Server immediately sends a tiny message to all relevant devices (that employee and, if needed, the team dashboard).
3. If a user disconnects and later returns, the app loads today’s records once from the API and then continues receiving live updates.

**What users see**

- Instant updates across web + mobile.
- No page refresh required.
- Multiple open tabs/devices stay in sync.


**Why this is better than polling**

Faster feedback (<1s).

Fewer API calls and lower load.

Simpler UX — the screen stays current on its own.

How to validate (quick)

Connect a WS client (e.g., WebSocket King).

Trigger a check‑in/checkout via API.

See the event appear instantly.

<img width="1537" height="878" alt="image" src="https://github.com/user-attachments/assets/8969fb57-94c3-457a-a444-37a80dabb548" />

