### PR TITLE
feat: enhance leave notification system with WebSocket support and notification formatting

### DIFF
--- a/Tara/consumer.py
+++ b/Tara/consumer.py
@@ -4,6 +4,7 @@ from channels.generic.websocket import AsyncWebsocketConsumer
 from django.utils.timezone import localdate
 from channels.db import database_sync_to_async
 from django.utils import timezone
+from payroll.utils import format_time_style
 
 
 class AttendanceConsumer(AsyncWebsocketConsumer):
@@ -32,6 +33,92 @@ class AttendanceConsumer(AsyncWebsocketConsumer):
 
 
 
+# class LeaveNotificationConsumer(AsyncWebsocketConsumer):
+#     async def connect(self):
+#         self.employee_id = self.scope["url_route"]["kwargs"]["employee_id"]
+#         print(f"WebSocket connected for employee_id: {self.employee_id}")
+#
+#         self.user_group = f"user_{self.employee_id}"
+#         await self.channel_layer.group_add(self.user_group, self.channel_name)
+#         await self.accept()
+#         await self.send(text_data=json.dumps({
+#             "type": "ws_connected",
+#             "employee_id": self.employee_id
+#         }))
+#
+#     async def disconnect(self, close_code):
+#         await self.channel_layer.group_discard(self.user_group, self.channel_name)
+#
+#     async def receive(self, text_data):
+#         """Handle messages from WebSocket client"""
+#         data = json.loads(text_data)
+#
+#         if data.get('type') == 'mark_read':
+#             notification_id = data.get('notification_id')
+#             try:
+#                 notification = await self.get_notification(notification_id)
+#                 await self.mark_notification_read(notification)
+#                 unread_count = await self.get_unread_count()
+#
+#                 payload = {
+#                     "type": "leave_notification",
+#                     "action": "read",
+#                     "notification_id": notification_id,
+#                     "unread_count": unread_count
+#                 }
+#
+#                 await self.channel_layer.group_send(
+#                     self.user_group,
+#                     {
+#                         "type": "send_leave_notification",
+#                         "payload": payload
+#                     }
+#                 )
+#
+#             except Exception as e:
+#                 await self.send(text_data=json.dumps({
+#                     "type": "error",
+#                     "message": str(e)
+#                 }))
+#
+#     async def send_leave_notification(self, event):
+#         """Handle incoming notification events"""
+#         try:
+#             await self.send(text_data=json.dumps(event["payload"]))
+#         except Exception as e:
+#             print(f"Error sending notification: {str(e)}")  # Debug print
+#             await self.send(text_data=json.dumps({
+#                 "type": "error",
+#                 "message": "Error processing notification"
+#             }))
+#
+#     @database_sync_to_async
+#     def get_notification(self, notification_id):
+#         # Import models here instead of at module level
+#         from payroll.models import LeaveNotification
+#         return LeaveNotification.objects.get(
+#             id=notification_id,
+#             reviewer_id=self.employee_id
+#         )
+#
+#     @database_sync_to_async
+#     def mark_notification_read(self, notification):
+#         notification.is_read = True
+#         notification.read_at = timezone.now()
+#         notification.save()
+#         return notification
+#
+#     @database_sync_to_async
+#     def get_unread_count(self):
+#         # Import models here instead of at module level
+#         from payroll.models import LeaveNotification
+#         return LeaveNotification.objects.filter(
+#             reviewer_id=self.employee_id,
+#             is_read=False
+#         ).count()
+
+
+
 class LeaveNotificationConsumer(AsyncWebsocketConsumer):
     async def connect(self):
         self.employee_id = self.scope["url_route"]["kwargs"]["employee_id"]
@@ -51,67 +138,133 @@ class LeaveNotificationConsumer(AsyncWebsocketConsumer):
     async def receive(self, text_data):
         """Handle messages from WebSocket client"""
         data = json.loads(text_data)
-        
+
         if data.get('type') == 'mark_read':
             notification_id = data.get('notification_id')
             try:
                 notification = await self.get_notification(notification_id)
-                await self.mark_notification_read(notification)
-                unread_count = await self.get_unread_count()
-                
-                payload = {
-                    "type": "leave_notification",
-                    "action": "read",
-                    "notification_id": notification_id,
-                    "unread_count": unread_count
-                }
-                
-                await self.channel_layer.group_send(
-                    self.user_group,
-                    {
-                        "type": "send_leave_notification",
-                        "payload": payload
+                if notification:
+                    await self.mark_notification_read(notification)
+                    notifications_data = await self.get_all_notifications()
+                    unread_count = await self.get_unread_count()
+
+                    # Format read time for the notification that was just read
+                    read_time = format_time_style(timezone.now())
+
+                    payload = {
+                        "type": "leave_notifications_update",
+                        "notifications": notifications_data,
+                        "unread_count": unread_count,
+                        "last_read_notification": {
+                            "notification_id": notification_id,
+                            "read_at": read_time
+                        }
                     }
-                )
-            
+
+                    await self.channel_layer.group_send(
+                        self.user_group,
+                        {
+                            "type": "send_leave_notification",
+                            "payload": payload
+                        }
+                    )
+
             except Exception as e:
+                print(f"Error in receive: {str(e)}")  # Debug log
                 await self.send(text_data=json.dumps({
                     "type": "error",
                     "message": str(e)
                 }))
 
     async def send_leave_notification(self, event):
-        """Handle incoming notification events"""
         try:
-            await self.send(text_data=json.dumps(event["payload"]))
+            payload = event["payload"]
+            await self.send(text_data=json.dumps(payload))
         except Exception as e:
-            print(f"Error sending notification: {str(e)}")  # Debug print
+            print(f"Error sending notification: {str(e)}")
             await self.send(text_data=json.dumps({
                 "type": "error",
                 "message": "Error processing notification"
             }))
 
+
+    @database_sync_to_async
+    def get_all_notifications(self):
+        """Get all notifications for the reviewer"""
+        from payroll.models import LeaveNotification
+
+        notifications = LeaveNotification.objects.select_related(
+            'leave_application',
+            'leave_application__employee',
+            'leave_application__employee__employee',
+            'leave_application__employee__employee__designation',
+            'leave_application__employee__employee__department',
+            'leave_application__leave_type'
+        ).filter(
+            reviewer_id=self.employee_id
+        ).order_by('-created_at')
+
+        notifications_data = []
+        for notif in notifications:
+            leave = notif.leave_application
+            employee = leave.employee.employee
+
+            notification_data = {
+                "type": "leave_notification",
+                "action": "view_leave",
+                "notification_id": notif.id,
+                "title": f"{employee.first_name} {employee.last_name} - {leave.leave_type.name_of_leave} Request",
+                "data": {
+                    "employee": {
+                        "name": f"{employee.first_name} {employee.last_name}",
+                        "designation": employee.designation.designation_name if employee.designation else "N/A",
+                        "department": employee.department.dept_name if employee.department else "N/A",
+                        "role": "Reviewer" if leave.reviewer_id == self.employee_id else "CC"
+                    },
+                    "leave": {
+                        "id": leave.id,
+                        "type": leave.leave_type.name_of_leave,
+                        "days": (leave.end_date - leave.start_date).days + 1,
+                        "period": f"{leave.start_date.strftime('%d %b %Y')} to {leave.end_date.strftime('%d %b %Y')}",
+                        "reason": leave.reason,
+                        "status": leave.status
+                    }
+                },
+                "message": notif.message,
+                "created_at": format_time_style(notif.created_at),
+                "is_read": notif.is_read,
+                "read_at": format_time_style(notif.read_at)
+            }
+            notifications_data.append(notification_data)
+
+        return notifications_data
+
     @database_sync_to_async
     def get_notification(self, notification_id):
-        # Import models here instead of at module level
         from payroll.models import LeaveNotification
-        return LeaveNotification.objects.get(
-            id=notification_id, 
-            reviewer_id=self.employee_id
-        )
+        try:
+            return LeaveNotification.objects.select_related(
+                'leave_application',
+                'leave_application__employee'
+            ).get(
+                id=notification_id,
+                reviewer_id=self.employee_id
+            )
+        except LeaveNotification.DoesNotExist:
+            return None
 
     @database_sync_to_async
     def mark_notification_read(self, notification):
+        current_time = timezone.now()
         notification.is_read = True
-        notification.read_at = timezone.now()
-        notification.save()
+        notification.read_at = current_time
+        notification.save(update_fields=['is_read', 'read_at'])
         return notification
 
     @database_sync_to_async
     def get_unread_count(self):
-        # Import models here instead of at module level
         from payroll.models import LeaveNotification
         return LeaveNotification.objects.filter(
-            reviewer_id=self.employee_id, 
+            reviewer_id=self.employee_id,
             is_read=False
         ).count()

--- a/payroll/urls.py
+++ b/payroll/urls.py
@@ -280,7 +280,7 @@ urlpatterns = [
     path('my-leave-balances/', leavemanagement.get_my_leave_balances, name='my_leave_balances'),
 
     # Employee Leave Notifications
-    path('leave-notifications/<int:notification_id>/', leavemanagement.get_leave_notification_details, name='leave-notification-details'),
+    path('leave-notifications/', leavemanagement.get_leave_notifications, name='leave-notification-details'),
     path('unread-notifications-count/', leavemanagement.unread_leave_notification_count, name='unread_leave_notifications'),
 
     # Employee Education Endpoints

--- a/payroll/utils.py
+++ b/payroll/utils.py
@@ -1,0 +1,25 @@
+from django.utils import timezone
+
+def format_time_style(timestamp):
+    """Format time for notifications"""
+    if not timestamp:
+        return None
+
+    now = timezone.now()
+    created = timezone.localtime(timestamp)
+    diff = now - created
+
+    if diff.days == 0:
+        return {
+            "display": created.strftime("%I:%M %p").lstrip('0')
+        }
+    elif diff.days == 1:
+        return {
+            "date": "Yesterday",
+            "time": created.strftime("%I:%M %p").lstrip('0')
+        }
+    else:
+        return {
+            "date": created.strftime("%d %B, %Y"),
+            "time": created.strftime("%I:%M %p").lstrip('0')
+        }


### PR DESCRIPTION
**Leave Application Notifications Enhancement**
**Changes Made**

- Enhanced leave application notifications to include both reviewer and CC recipients
- Optimized database queries and added bulk operations
- Added proper error handling and logging
- Improved WebSocket payload structure

**API Changes**
GET /api/leave-notifications/
Returns all notifications for the logged-in user (both as reviewer and CC)
```json
{
  "notifications": [
    {
      "type": "leave_notification",
      "action": "view_leave",
      "notification_id": 123,
      "title": "John Doe - Casual Leave Request",
      "data": {
        "employee": {
          "name": "John Doe",
          "designation": "Developer",
          "department": "IT",
          "role": "Reviewer"
        },
        "leave": {
          "id": 456,
          "type": "Casual Leave",
          "days": 2,
          "period": "21 Dec 2023 to 22 Dec 2023",
          "reason": "Personal work",
          "status": "pending"
        }
      },
      "message": "Detailed leave request message",
      "created_at": {"display": "2:30 PM"},
      "is_read": false,
      "read_at": null
    }
  ],
  "unread_count": 5
}
```

**WebSocket Updates**

- Now includes role information (Reviewer/CC) in notifications
- Real-time updates for both reviewers and CC recipients
- Consistent timestamp formatting
- Enhanced error handling

**Performance Improvements**

- Added database transactions for data consistency
- Implemented bulk create for notifications
- Optimized database queries using select_related
- Reduced duplicate queries

**Screenshots**

**Leave application form with CC selection**

<img width="1920" height="1080" alt="Screenshot (397)" src="https://github.com/user-attachments/assets/2d169244-7a10-4113-a6cf-96924be378b2" />

**Reviewer's notification view**

<img width="1920" height="1080" alt="Screenshot (399)" src="https://github.com/user-attachments/assets/fc4c04f1-bd1d-453a-9fdb-96037f95a182" />

**CC recipient's notification view**

<img width="1920" height="1080" alt="Screenshot (398)" src="https://github.com/user-attachments/assets/3f4cad01-0a81-48da-a383-c4051a68adfb" />

**Read/unread state changes**

<img width="1920" height="1080" alt="Screenshot (400)" src="https://github.com/user-attachments/assets/5e5988d9-9cb0-4118-8312-b89f16ea387d" />
